### PR TITLE
Add dummy test

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -20,7 +20,7 @@ module.exports = defineConfig({
       name: 'Chrome',
       use: {
         ...devices['Desktop Chrome'], // Use Chrome browser
-        headless: false, // Run in headless mode
+        headless: true, // Run in headless mode
         viewport: { width: 1280, height: 720 },
         ignoreHTTPSErrors: true,
         video: 'retain-on-failure',
@@ -59,7 +59,7 @@ module.exports = defineConfig({
       name: 'Android',
       use: {
         ...devices['Pixel 5'], // Use Android device (Pixel 5)
-        headless: false, // Run in non-headless mode for mobile
+        headless: true, // Run in headless mode for mobile
         ignoreHTTPSErrors: true,
         video: 'retain-on-failure',
         screenshot: 'only-on-failure',
@@ -71,7 +71,7 @@ module.exports = defineConfig({
       name: 'iPhone',
       use: {
         ...devices['iPhone 12'], // Use iPhone device (iPhone 12)
-        headless: false, // Run in non-headless mode for mobile
+        headless: true, // Run in headless mode for mobile
         ignoreHTTPSErrors: true,
         video: 'retain-on-failure',
         screenshot: 'only-on-failure',

--- a/tests/dummy_e2e_demo_ai.js
+++ b/tests/dummy_e2e_demo_ai.js
@@ -1,0 +1,46 @@
+const { test, expect } = require('@playwright/test');
+const { HomePage } = require('../Pages/HomePage');
+const { FlightsPage } = require('../Pages/FlightsPage');
+const { PurchasePage } = require('../Pages/PurchasePage');
+const { ConfirmationPage } = require('../Pages/ConfirmationPage');
+
+// Dummy data inline to avoid loading files
+const flightData = { departureCity: 'Denver', destinationCity: 'London' };
+const passengerInfo = {
+  name: 'Alice Tester',
+  address: '123 Main St',
+  city: 'Denver',
+  state: 'CO',
+  zipCode: '80014'
+};
+const paymentInfo = {
+  creditCardNumber: '4111111111111111',
+  creditCardMonth: '12',
+  creditCardYear: '2030',
+  nameOnCard: 'Alice Tester'
+};
+
+test('Dummy e2e reservation using POM', async ({ page }) => {
+  const homePage = new HomePage(page);
+  const flightsPage = new FlightsPage(page);
+  const purchasePage = new PurchasePage(page);
+  const confirmationPage = new ConfirmationPage(page);
+
+  await homePage.goto();
+  await homePage.verifyHomePageLoaded();
+  await homePage.selectDepartureCity(flightData.departureCity);
+  await homePage.selectDestinationCity(flightData.destinationCity);
+  await homePage.findFlights();
+
+  await flightsPage.verifyFlightsPage(flightData.departureCity, flightData.destinationCity);
+  await flightsPage.verifyFlightsDisplayed();
+  await flightsPage.selectFirstFlight();
+
+  await purchasePage.verifyPurchasePageLoaded();
+  await purchasePage.fillPassengerInfo(passengerInfo);
+  await purchasePage.fillPaymentInfo(paymentInfo);
+  await purchasePage.purchaseFlight();
+
+  await confirmationPage.verifyConfirmationPage();
+  await confirmationPage.verifyConfirmationDetails();
+});


### PR DESCRIPTION
## Summary
- add headless mode for all projects in Playwright config
- add a small dummy e2e test as an example

## Testing
- `npx playwright install chromium` *(fails: 403 Domain forbidden)*
- `npx playwright test tests/dummy_e2e_demo_ai.js --project=Chrome --timeout=0` *(fails: browser executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_6847f14ad94c8325882ffb54dacf3e61