### PR TITLE
Add negative test case

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENT Instructions
+
+This repository contains a Playwright-based automation framework.
+
+Key elements include:
+
+- Test execution script `run-e2e.sh` installs dependencies and runs Playwright tests.
+- Playwright configuration `playwright.config.js` defines test directories, projects (Chrome, Firefox, Edge, Android, iPhone) and reporters.
+- Page Object classes are located in `Pages/` (e.g., `HomePage.js`, `FlightsPage.js`, etc.) for actions on the BlazeDemo site.
+- Automated tests reside under `tests/` (e.g., `demo.js`, `demo_ai.js`, `skip_clock.js`, etc.).
+- Test data files can be found in `data/`.
+
+## Testing
+- Install dependencies with `npm ci`.
+- Run tests with `npx playwright test`.
+- HTML and other reports are generated under `reports/`.
+
+## Guidelines
+- Do **not** commit secrets such as tokens. Use environment variables instead.
+- Avoid committing `node_modules`, reports, screenshots, or other generated artifacts.
+- Placeholder files like `.gitignore` or `LICENSE` may need cleanup.
+
+Use `playwright.config.js` to adjust browser settings or test behavior.

--- a/data/flightData2.json
+++ b/data/flightData2.json
@@ -1,0 +1,4 @@
+{
+  "departureCity": "Los Angeles",
+  "destinationCity": "San Francisco"
+}

--- a/data/flightData3.json
+++ b/data/flightData3.json
@@ -1,0 +1,4 @@
+{
+  "departureCity": "Chicago",
+  "destinationCity": "Denver"
+}

--- a/data/flightData4.json
+++ b/data/flightData4.json
@@ -1,0 +1,4 @@
+{
+  "departureCity": "Miami",
+  "destinationCity": "Seattle"
+}

--- a/data/flightData5.json
+++ b/data/flightData5.json
@@ -1,0 +1,4 @@
+{
+  "departureCity": "Dallas",
+  "destinationCity": "Austin"
+}

--- a/data/flightData6.json
+++ b/data/flightData6.json
@@ -1,0 +1,4 @@
+{
+  "departureCity": "Atlantis",
+  "destinationCity": "Narnia"
+}

--- a/data/flightData7.json
+++ b/data/flightData7.json
@@ -1,0 +1,4 @@
+{
+  "departureCity": "",
+  "destinationCity": ""
+}

--- a/data/flightData8.json
+++ b/data/flightData8.json
@@ -1,0 +1,4 @@
+{
+  "departureCity": "東京",
+  "destinationCity": "Москва"
+}

--- a/data/flightData9.json
+++ b/data/flightData9.json
@@ -1,0 +1,4 @@
+{
+  "departureCity": "S\u00e3o Paulo",
+  "destinationCity": "Cape Town"
+}

--- a/data/passengerInfo2.json
+++ b/data/passengerInfo2.json
@@ -1,0 +1,7 @@
+{
+  "name": "Jane Smith",
+  "address": "456 Oak Avenue",
+  "city": "Los Angeles",
+  "state": "CA",
+  "zipCode": "90001"
+}

--- a/data/passengerInfo3.json
+++ b/data/passengerInfo3.json
@@ -1,0 +1,7 @@
+{
+  "name": "Alice Johnson",
+  "address": "789 Pine Road",
+  "city": "Chicago",
+  "state": "IL",
+  "zipCode": "60605"
+}

--- a/data/passengerInfo4.json
+++ b/data/passengerInfo4.json
@@ -1,0 +1,7 @@
+{
+  "name": "Bob Brown",
+  "address": "321 Maple Lane",
+  "city": "Miami",
+  "state": "FL",
+  "zipCode": "33101"
+}

--- a/data/passengerInfo5.json
+++ b/data/passengerInfo5.json
@@ -1,0 +1,7 @@
+{
+  "name": "Carlos Diaz",
+  "address": "654 Cedar Blvd",
+  "city": "Dallas",
+  "state": "TX",
+  "zipCode": "75201"
+}

--- a/data/passengerInfo6.json
+++ b/data/passengerInfo6.json
@@ -1,0 +1,7 @@
+{
+  "name": "",
+  "address": "",
+  "city": "",
+  "state": "",
+  "zipCode": "abcde"
+}

--- a/data/passengerInfo7.json
+++ b/data/passengerInfo7.json
@@ -1,0 +1,7 @@
+{
+  "name": "Test",
+  "address": "",
+  "city": "",
+  "state": "",
+  "zipCode": "00000"
+}

--- a/data/passengerInfo8.json
+++ b/data/passengerInfo8.json
@@ -1,0 +1,7 @@
+{
+  "name": "\u0141ukasz \u017Bo\u0142\u0107",
+  "address": "\u015Aw\u0119tokrzyska 1",
+  "city": "Warszawa",
+  "state": "Mazowieckie",
+  "zipCode": "00-001"
+}

--- a/data/passengerInfo9.json
+++ b/data/passengerInfo9.json
@@ -1,0 +1,7 @@
+{
+  "name": "O'Connor, Sean \"The Shark\"",
+  "address": "1 Infinite Loop\nSuite 42",
+  "city": "S\u00e3o Paulo",
+  "state": "SP",
+  "zipCode": "01000-000"
+}

--- a/data/paymentInfo2.json
+++ b/data/paymentInfo2.json
@@ -1,0 +1,6 @@
+{
+  "creditCardNumber": "4012888888881881",
+  "creditCardMonth": "10",
+  "creditCardYear": "2026",
+  "nameOnCard": "Jane Smith"
+}

--- a/data/paymentInfo3.json
+++ b/data/paymentInfo3.json
@@ -1,0 +1,6 @@
+{
+  "creditCardNumber": "5555555555554444",
+  "creditCardMonth": "08",
+  "creditCardYear": "2024",
+  "nameOnCard": "Alice Johnson"
+}

--- a/data/paymentInfo4.json
+++ b/data/paymentInfo4.json
@@ -1,0 +1,6 @@
+{
+  "creditCardNumber": "378282246310005",
+  "creditCardMonth": "09",
+  "creditCardYear": "2024",
+  "nameOnCard": "Bob Brown"
+}

--- a/data/paymentInfo5.json
+++ b/data/paymentInfo5.json
@@ -1,0 +1,6 @@
+{
+  "creditCardNumber": "6011111111111117",
+  "creditCardMonth": "05",
+  "creditCardYear": "2028",
+  "nameOnCard": "Carlos Diaz"
+}

--- a/data/paymentInfo6.json
+++ b/data/paymentInfo6.json
@@ -1,0 +1,6 @@
+{
+  "creditCardNumber": "1234567890123456",
+  "creditCardMonth": "00",
+  "creditCardYear": "1999",
+  "nameOnCard": ""
+}

--- a/data/paymentInfo7.json
+++ b/data/paymentInfo7.json
@@ -1,0 +1,6 @@
+{
+  "creditCardNumber": "",
+  "creditCardMonth": "",
+  "creditCardYear": "",
+  "nameOnCard": ""
+}

--- a/data/paymentInfo8.json
+++ b/data/paymentInfo8.json
@@ -1,0 +1,6 @@
+{
+  "creditCardNumber": "3566002020360505",
+  "creditCardMonth": "07",
+  "creditCardYear": "2030",
+  "nameOnCard": "\u0141ukasz \u017Bo\u0142\u0107"
+}

--- a/data/paymentInfo9.json
+++ b/data/paymentInfo9.json
@@ -1,0 +1,6 @@
+{
+  "creditCardNumber": "3530111333300000",
+  "creditCardMonth": "03",
+  "creditCardYear": "2032",
+  "nameOnCard": "O'Connor, Sean \"The Shark\""
+}

--- a/tests/demo_invalid.js
+++ b/tests/demo_invalid.js
@@ -1,0 +1,32 @@
+const { test, expect } = require('@playwright/test');
+const { HomePage } = require('../Pages/HomePage');
+const { FlightsPage } = require('../Pages/FlightsPage');
+const { PurchasePage } = require('../Pages/PurchasePage');
+const { ConfirmationPage } = require('../Pages/ConfirmationPage');
+
+const flightData = require('../data/flightData6.json');
+const passengerInfo = require('../data/passengerInfo6.json');
+const paymentInfo = require('../data/paymentInfo6.json');
+
+test('Handle invalid flight data gracefully', async ({ page }) => {
+  // Fail fast when invalid cities are used
+  test.setTimeout(5000);
+  page.setDefaultTimeout(1000);
+  const { departureCity, destinationCity } = flightData;
+
+  const homePage = new HomePage(page);
+  const flightsPage = new FlightsPage(page);
+  const purchasePage = new PurchasePage(page);
+  const confirmationPage = new ConfirmationPage(page);
+
+  await homePage.goto();
+  await homePage.verifyHomePageLoaded();
+
+  await expect(async () => {
+    await homePage.selectDepartureCity(departureCity);
+  }).rejects.toThrow();
+
+  await expect(async () => {
+    await homePage.selectDestinationCity(destinationCity);
+  }).rejects.toThrow();
+});


### PR DESCRIPTION
## Summary
- add demo_invalid.js for negative data
- shorten timeouts so invalid data fails fast

## Testing
- `npm ci` *(fails: lock file out of sync)*
- `npx playwright test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684831753a8083258210595f543c9e43