### PR TITLE
Add failing invalid data test

### DIFF
--- a/data/flightData_invalid.json
+++ b/data/flightData_invalid.json
@@ -1,0 +1,4 @@
+{
+  "departureCity": "NowhereCity",
+  "destinationCity": "InvalidTown"
+}

--- a/data/passengerInfo_invalid.json
+++ b/data/passengerInfo_invalid.json
@@ -1,0 +1,7 @@
+{
+  "name": "",
+  "address": "",
+  "city": "",
+  "state": "",
+  "zipCode": ""
+}

--- a/data/paymentInfo_invalid.json
+++ b/data/paymentInfo_invalid.json
@@ -1,0 +1,6 @@
+{
+  "creditCardNumber": "123",
+  "creditCardMonth": "00",
+  "creditCardYear": "1900",
+  "nameOnCard": ""
+}

--- a/tests/demo_invalid.js
+++ b/tests/demo_invalid.js
@@ -1,0 +1,45 @@
+// tests/demo_invalid.js
+
+const { test, expect } = require('@playwright/test');
+const { HomePage } = require('../Pages/HomePage');
+const { FlightsPage } = require('../Pages/FlightsPage');
+const { PurchasePage } = require('../Pages/PurchasePage');
+const { ConfirmationPage } = require('../Pages/ConfirmationPage');
+
+const flightData = require('../data/flightData_invalid.json');
+const passengerInfo = require('../data/passengerInfo_invalid.json');
+const paymentInfo = require('../data/paymentInfo_invalid.json');
+
+// This test uses invalid data and is expected to fail quickly.
+test('Attempt booking with invalid data', async ({ page }) => {
+  // Reduce default timeout so failures surface fast
+  page.setDefaultTimeout(2000);
+
+  const { departureCity, destinationCity } = flightData;
+
+  const homePage = new HomePage(page);
+  const flightsPage = new FlightsPage(page);
+  const purchasePage = new PurchasePage(page);
+  const confirmationPage = new ConfirmationPage(page);
+
+  await homePage.goto();
+  await homePage.verifyHomePageLoaded();
+
+  // These selections are expected to fail because the cities do not exist
+  await homePage.selectDepartureCity(departureCity);
+  await homePage.selectDestinationCity(destinationCity);
+
+  // If somehow the cities were selected, continue with the flow
+  await homePage.findFlights();
+  await flightsPage.verifyFlightsPage(departureCity, destinationCity);
+  await flightsPage.verifyFlightsDisplayed();
+  await flightsPage.selectFirstFlight();
+
+  await purchasePage.verifyPurchasePageLoaded();
+  await purchasePage.fillPassengerInfo(passengerInfo);
+  await purchasePage.fillPaymentInfo(paymentInfo);
+  await purchasePage.purchaseFlight();
+
+  await confirmationPage.verifyConfirmationPage();
+  await confirmationPage.verifyConfirmationDetails();
+});


### PR DESCRIPTION
## Summary
- add invalid passenger, payment, and flight test data
- create `demo_invalid.js` that uses the new data and short timeouts so it fails quickly

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68486bfd26508325be7c4a436e0865bd